### PR TITLE
Correção: largura dinâmica da ProgressBar

### DIFF
--- a/src/components/ProgressBar/ProgressBar.module.css
+++ b/src/components/ProgressBar/ProgressBar.module.css
@@ -1,6 +1,5 @@
 .container_external_light,
 .container_external_dark {
-  width: 342px;
   overflow: hidden;
 }
 

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -4,6 +4,7 @@ import styles from "./ProgressBar.module.css";
 type ProgressBarProps = {
   size?: "large" | "medium" | "small";
   color?: "light" | "dark";
+  width?: number;
   totalValue: number;
   relativeValue: number;
 };
@@ -11,13 +12,15 @@ type ProgressBarProps = {
 const ProgressBar = ({
   size = "medium",
   color = "dark",
+  width = 342,
   totalValue,
   relativeValue,
 }: ProgressBarProps) => {
-  const internalDivWidth = (relativeValue * 342) / totalValue;
+  const internalDivWidth = (relativeValue * width) / totalValue;
 
   return (
     <div
+      style={{ width: width }}
       className={`${styles[size]} ${styles.container_external} ${
         color === "light"
           ? styles.container_external_light


### PR DESCRIPTION
Para alterar a largura da barra é necessário passá-la em pixels como props para o componente.