### PR TITLE
Fix DropDown

### DIFF
--- a/src/components/Dropdown/Dropdown.module.css
+++ b/src/components/Dropdown/Dropdown.module.css
@@ -3,7 +3,7 @@
 
 .dropdown_container {
   flex-shrink: 0;
-  min-width: 242px;
+  /* min-width: 242px; */
 }
 
 .dropdown,

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -9,7 +9,7 @@ type DropdownProps = {
   id: string;
   size?: "small" | "micro" | "default" | "large";
   initialText?: string;
-  width?: number;
+  width: number;
   disabled?: boolean;
   leftIcon?: JSX.Element;
 };
@@ -54,7 +54,7 @@ const Dropdown = ({
         ].join(" ")}
       >
         <div className={styles.inner_left}>
-          {leftIcon ?? <IconEye />}
+          {leftIcon}
           {placeholder}
         </div>
         <IconArrow />

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import styles from "./Dropdown.module.css";
-import IconEye from "@mui/icons-material/VisibilityOutlined";
 import IconArrow from "@mui/icons-material/KeyboardArrowDownOutlined";
 
 type DropdownProps = {


### PR DESCRIPTION
Estava com ícone à esquerda mesmo quando não precisava. O ícone foi removido quando não era declarado;
Corrigido bug da largura das opções não estar adequando automaticamente.